### PR TITLE
Convert pvs/simple-java-maven-app_gha to GitHub Actions

### DIFF
--- a/.github/workflows/simple-java-maven-app_gha.yml
+++ b/.github/workflows/simple-java-maven-app_gha.yml
@@ -1,0 +1,35 @@
+name: pvs/simple-java-maven-app_gha
+on:
+  workflow_dispatch:
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.5.0
+    - name: sh
+      shell: bash
+      run: mvn -B -DskipTests clean package
+  Test:
+    runs-on: ubuntu-latest
+    needs: Build
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.5.0
+    - name: sh
+      shell: bash
+      run: mvn test
+    - name: Publish test results
+      uses: EnricoMi/publish-unit-test-result-action@v2.7.0
+      if: always()
+      with:
+        junit_files: target/surefire-reports/*.xml
+  Deliver:
+    runs-on: ubuntu-latest
+    needs: Test
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.5.0
+    - name: sh
+      shell: bash
+      run: "./jenkins/scripts/deliver.sh"


### PR DESCRIPTION
Pipeline migrated from [Jenkins](http://13.232.224.33:8080/job/pvs/job/simple-java-maven-app_gha) :tada:

## Manual steps

Perform the following steps to complete the migration:

### pvs/simple-java-maven-app_gha
- [x] Ensure build tool is available: `maven`